### PR TITLE
Expose underlying C API

### DIFF
--- a/src/zuckdb.zig
+++ b/src/zuckdb.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const lib = @import("lib.zig");
 
+pub const c = lib.c;
 pub const DB = lib.DB;
 pub const Row = lib.Row;
 pub const List = lib.List;


### PR DESCRIPTION
Having access to underlying DuckDB APIs is useful as directly importing `duckdb.h` in user code leads to compile errors. C structs that originate from different `cimport.zig` files are not considered to be the same type.