### PR TITLE
add include path to zuckdb module to find the duckdb.h file

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3,34 +3,35 @@ const std = @import("std");
 const LazyPath = std.Build.LazyPath;
 
 pub fn build(b: *std.Build) !void {
-	const target = b.standardTargetOptions(.{});
-	const optimize = b.standardOptimizeOption(.{});
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
 
-	const lib_path = b.path("lib");
+    const lib_path = b.path("lib");
 
-	_ = b.addModule("zuckdb", .{
-		.root_source_file = b.path("src/zuckdb.zig"),
-	});
+    const zuckdb = b.addModule("zuckdb", .{
+        .root_source_file = b.path("src/zuckdb.zig"),
+    });
+    zuckdb.addIncludePath(b.path("lib/"));
 
-	{
-		// Setup Tests
-		const lib_test = b.addTest(.{
-			.root_source_file = b.path("src/zuckdb.zig"),
-			.target = target,
-			.optimize = optimize,
-			.test_runner = b.path("test_runner.zig"),
-		});
+    {
+        // Setup Tests
+        const lib_test = b.addTest(.{
+            .root_source_file = b.path("src/zuckdb.zig"),
+            .target = target,
+            .optimize = optimize,
+            .test_runner = b.path("test_runner.zig"),
+        });
 
-		lib_test.addRPath(lib_path);
-		lib_test.addIncludePath(lib_path);
-		lib_test.addLibraryPath(lib_path);
-		lib_test.linkSystemLibrary("duckdb");
-		lib_test.linkLibC();
+        lib_test.addRPath(lib_path);
+        lib_test.addIncludePath(lib_path);
+        lib_test.addLibraryPath(lib_path);
+        lib_test.linkSystemLibrary("duckdb");
+        lib_test.linkLibC();
 
-		const run_test = b.addRunArtifact(lib_test);
-		run_test.has_side_effects = true;
+        const run_test = b.addRunArtifact(lib_test);
+        run_test.has_side_effects = true;
 
-		const test_step = b.step("test", "Run unit tests");
-		test_step.dependOn(&run_test.step);
-	}
+        const test_step = b.step("test", "Run unit tests");
+        test_step.dependOn(&run_test.step);
+    }
 }


### PR DESCRIPTION
Add include path to zuckdb module  to find the built-in duckdb.h file, then avoid entering:
```zuckdb.addIncludePath(b.path("lib/"));```
in user's build.zig file.