### PR TITLE
Build libduckdb from amalgamation release

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,6 +6,7 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const system_libduckdb = b.option(bool, "system-libduckdb", "link with system libduckdb") orelse false;
+    const debug_duckdb = b.option(bool, "debug-duckdb", "compile duckdb with DUCKDB_DEBUG_STACKTRACE") orelse false;
 
     const zuckdb = b.addModule("zuckdb", .{
         .root_source_file = b.path("src/zuckdb.zig"),
@@ -33,6 +34,19 @@ pub fn build(b: *std.Build) !void {
                     .files = &.{"duckdb.cpp"},
                     .root = c_dep.path(""),
                 });
+                if (debug_duckdb) {
+                    c_lib.root_module.addCMacro("DUCKDB_DEBUG_STACKTRACE", "");
+                }
+                c_lib.root_module.addCMacro("DUCKDB_STATIC_BUILD", "");
+                // json tests fail because extension loading does not work
+                // on the self built version. TODO: statically link core extensions:
+                // c_lib.root_module.addCMacro("DUCKDB_EXTENSION_JSON_LINKED", "true");
+                b.installArtifact(c_lib);
+                b.default_step.dependOn(&b.addInstallHeaderFile(
+                    c_dep.path("duckdb.h"),
+                    "duckdb.h",
+                ).step);
+
                 zuckdb.linkLibrary(c_lib);
                 break :blk c_dep.path("duckdb.h");
             } else {
@@ -51,6 +65,11 @@ pub fn build(b: *std.Build) !void {
         // Setup Tests
         const lib_test = b.addTest(.{
             .root_module = zuckdb,
+            .filters = b.option(
+                []const []const u8,
+                "test-filter",
+                "test-filter",
+            ) orelse &.{},
             .test_runner = b.path("test_runner.zig"),
         });
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,12 @@
 .{
-  .name = "zuckdb",
-  .paths = .{""},
-  .version = "0.0.0",
-  .dependencies = .{
-  },
+    .name = "zuckdb",
+    .paths = .{""},
+    .version = "0.0.0",
+    .dependencies = .{
+        .duckdb = .{
+            .lazy = true,
+            .url = "https://github.com/duckdb/duckdb/releases/download/v1.1.3/libduckdb-src.zip",
+            .hash = "122081554b2ca7ea7fb02462dda7ec41c39ca42e6b8e663b3636ee10eb3cb86cef55",
+        },
+    },
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -1,4 +1,4 @@
-pub const c = @cImport(@cInclude("duckdb.h"));
+pub const c = @import("duckdb_clib");
 
 const row = @import("row.zig");
 pub const Row = row.Row;


### PR DESCRIPTION
To remove the dependency on the system library, we can build libduckdb from the release amalgamation (latest release v1.1.3).

I also refactored the build.zig to translate the c header and pass it as a module instead of
using `cInclude`, zig plans to remove that feature in perspective.

Building the amalgamation needs a lot of memory though, (>16Gb) on my machine.

```
Appender: json (59.89ms)
Appender: list simple types (78.11ms)
Appender: list multiple (59.16ms)
Appender: appendListMap int (58.45ms)
Appender: appendListMap text (59.11ms)
Appender: appendListMap date (58.19ms)
Appender: appendListMap time (58.83ms)
Appender: appendListMap timestamp (58.63ms)
Appender: appendListMap UUID (63.20ms)
Appender: incomplete row (58.95ms)

59 of 62 tests passed
```