### PR TITLE
fix: segmentation fault when checking null validity mask

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zuckdb,
     .paths = .{""},
     .version = "0.0.0",
-    .fingerprint = 0xe57532405497940e,
+    .fingerprint = 0xe57532404501c85c,
     .dependencies = .{
         .duckdb = .{
             .lazy = true,

--- a/src/row.zig
+++ b/src/row.zig
@@ -209,6 +209,9 @@ pub const LazyList = struct {
 };
 
 inline fn _isNull(validity: [*c]u64, index: usize) bool {
+    if (validity == 0) {
+        return false;
+    }
     const entry_index = index / 64;
     const entry_mask = index % 64;
     return validity[entry_index] & std.math.shl(u64, 1, entry_mask) == 0;


### PR DESCRIPTION
It is possible for the validity mask to be null if all values in the vector are valid.
https://duckdb.org/docs/stable/clients/c/vector#null-values

In this case the validity mask does not need to be checked. Otherwise `validity[entry_index]` segfaults.

This is a quick fix that seems to work for me, but if there's interest in merging this I'd be happy to contribute a more robust one. :)