### PR TITLE
Fix Build Dependency Loop

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -25,7 +25,10 @@ pub fn build(b: *std.Build) !void {
                 const lib_path = c_dep.path("");
                 const c_lib = b.addLibrary(.{
                     .name = "duckdb",
-                    .root_module = zuckdb,
+                    .root_module = b.createModule(.{
+                        .target = target,
+                        .optimize = optimize,
+                    }),
                 });
                 c_lib.linkLibCpp();
                 c_lib.addIncludePath(lib_path);


### PR DESCRIPTION
When trying to build with

```bash
zig build -Dsystem_libduckdb=false
```

with zig v0.15.2, I always saw errors like this:

```
dependency loop detected:
  compile lib duckdb Debug native
  compile lib duckdb Debug native
  install duckdb
  install
```

This PR fixes that issue, by not depending on the zuckdb module when building duckdb, but creating a seperate module.