### PR TITLE
Enable standalone builds, Make it possible to build in release-mode

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -35,7 +35,11 @@ pub fn build(b: *std.Build) !void {
                 c_lib.linkLibCpp();
                 const lib_path = c_dep.path("");
                 c_lib.addIncludePath(lib_path);
-                c_lib.addCSourceFiles(.{ .files = &.{"duckdb.cpp"}, .root = c_dep.path(""), .flags = &.{"-Wno-date-time"} });
+                c_lib.addCSourceFiles(.{
+                    .files = &.{"duckdb.cpp"},
+                    .root = c_dep.path(""),
+                    .flags = &.{"-Wno-date-time"},
+                });
                 if (debug_duckdb) {
                     c_lib.root_module.addCMacro("DUCKDB_DEBUG_STACKTRACE", "");
                 }

--- a/build.zig
+++ b/build.zig
@@ -22,15 +22,20 @@ pub fn build(b: *std.Build) !void {
             break :blk b.path("lib/duckdb.h");
         } else {
             if (b.lazyDependency("duckdb", .{})) |c_dep| {
-                const lib_path = c_dep.path("");
+                const root_module = b.createModule(.{
+                    .target = target,
+                    .optimize = optimize,
+                });
+                root_module.addCMacro("__DATE__", b.fmt("\"{d}\"", .{std.time.timestamp()}));
+                root_module.addCMacro("__TIME__", b.fmt("\"{d}\"", .{std.time.timestamp()}));
+
                 const c_lib = b.addLibrary(.{
                     .name = "duckdb",
-                    .root_module = b.createModule(.{
-                        .target = target,
-                        .optimize = optimize,
-                    }),
+                    .root_module = root_module,
                 });
+
                 c_lib.linkLibCpp();
+                const lib_path = c_dep.path("");
                 c_lib.addIncludePath(lib_path);
                 c_lib.addCSourceFiles(.{
                     .files = &.{"duckdb.cpp"},

--- a/build.zig
+++ b/build.zig
@@ -26,8 +26,6 @@ pub fn build(b: *std.Build) !void {
                     .target = target,
                     .optimize = optimize,
                 });
-                root_module.addCMacro("__DATE__", b.fmt("\"{d}\"", .{std.time.timestamp()}));
-                root_module.addCMacro("__TIME__", b.fmt("\"{d}\"", .{std.time.timestamp()}));
 
                 const c_lib = b.addLibrary(.{
                     .name = "duckdb",
@@ -37,10 +35,7 @@ pub fn build(b: *std.Build) !void {
                 c_lib.linkLibCpp();
                 const lib_path = c_dep.path("");
                 c_lib.addIncludePath(lib_path);
-                c_lib.addCSourceFiles(.{
-                    .files = &.{"duckdb.cpp"},
-                    .root = c_dep.path(""),
-                });
+                c_lib.addCSourceFiles(.{ .files = &.{"duckdb.cpp"}, .root = c_dep.path(""), .flags = &.{"-Wno-date-time"} });
                 if (debug_duckdb) {
                     c_lib.root_module.addCMacro("DUCKDB_DEBUG_STACKTRACE", "");
                 }

--- a/build.zig
+++ b/build.zig
@@ -14,50 +14,47 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
     });
 
-    const c_header: LazyPath = blk: {
+    const c_header: LazyPath, const lib = blk: {
         if (system_libduckdb) {
             const lib_path = b.path("lib");
             zuckdb.addIncludePath(lib_path);
             zuckdb.linkSystemLibrary("duckdb", .{});
-            break :blk b.path("lib/duckdb.h");
+            break :blk .{ b.path("lib/duckdb.h"), null };
         } else {
-            if (b.lazyDependency("duckdb", .{})) |c_dep| {
-                const root_module = b.createModule(.{
-                    .target = target,
-                    .optimize = optimize,
-                });
+            const c_dep = b.lazyDependency("duckdb", .{}) orelse return;
+            const root_module = b.createModule(.{
+                .target = target,
+                .optimize = optimize,
+            });
 
-                const c_lib = b.addLibrary(.{
-                    .name = "duckdb",
-                    .root_module = root_module,
-                });
+            const c_lib = b.addLibrary(.{
+                .name = "duckdb",
+                .root_module = root_module,
+            });
 
-                c_lib.linkLibCpp();
-                const lib_path = c_dep.path("");
-                c_lib.addIncludePath(lib_path);
-                c_lib.addCSourceFiles(.{
-                    .files = &.{"duckdb.cpp"},
-                    .root = c_dep.path(""),
-                    .flags = &.{"-Wno-date-time"},
-                });
-                if (debug_duckdb) {
-                    c_lib.root_module.addCMacro("DUCKDB_DEBUG_STACKTRACE", "");
-                }
-                c_lib.root_module.addCMacro("DUCKDB_STATIC_BUILD", "");
-                // json tests fail because extension loading does not work
-                // on the self built version. TODO: statically link core extensions:
-                // c_lib.root_module.addCMacro("DUCKDB_EXTENSION_JSON_LINKED", "true");
-                b.installArtifact(c_lib);
-                b.default_step.dependOn(&b.addInstallHeaderFile(
-                    c_dep.path("duckdb.h"),
-                    "duckdb.h",
-                ).step);
-
-                zuckdb.linkLibrary(c_lib);
-                break :blk c_dep.path("duckdb.h");
-            } else {
-                break :blk b.path("");
+            c_lib.linkLibCpp();
+            const lib_path = c_dep.path("");
+            c_lib.addIncludePath(lib_path);
+            c_lib.addCSourceFiles(.{
+                .files = &.{"duckdb.cpp"},
+                .root = c_dep.path(""),
+                .flags = &.{"-Wno-date-time"},
+            });
+            if (debug_duckdb) {
+                c_lib.root_module.addCMacro("DUCKDB_DEBUG_STACKTRACE", "");
             }
+            c_lib.root_module.addCMacro("DUCKDB_STATIC_BUILD", "");
+            // json tests fail because extension loading does not work
+            // on the self built version. TODO: statically link core extensions:
+            // c_lib.root_module.addCMacro("DUCKDB_EXTENSION_JSON_LINKED", "true");
+            b.installArtifact(c_lib);
+            b.default_step.dependOn(&b.addInstallHeaderFile(
+                c_dep.path("duckdb.h"),
+                "duckdb.h",
+            ).step);
+
+            zuckdb.linkLibrary(c_lib);
+            break :blk .{ c_dep.path("duckdb.h"), c_lib };
         }
     };
 
@@ -81,7 +78,11 @@ pub fn build(b: *std.Build) !void {
         lib_test.addRPath(b.path("lib"));
         lib_test.addIncludePath(b.path("lib"));
         lib_test.addLibraryPath(b.path("lib"));
-        lib_test.linkSystemLibrary("duckdb");
+        if (system_libduckdb) {
+            lib_test.linkSystemLibrary("duckdb");
+        } else {
+            lib_test.linkLibrary(lib.?);
+        }
 
         const run_test = b.addRunArtifact(lib_test);
         run_test.has_side_effects = true;


### PR DESCRIPTION
When building with ReleaseFast or ReleaseSmall, the compiler complained, that the `__DATE__` and `__TIME__` macros yield non-reproducible builds. These macros are explicitly used in a function that is commented with "sometimes you want different behaviors based on when the lib was compiled.

I'm disabling the `date-time` warning, as it's expected behavior from DuckDB.

Additionally, I've refactored `build.zig`, so that it's now possible to build the library without having libduckdb installed on the system.

Previously, the testing-target still linked to the system-wide libduckdb installation